### PR TITLE
Don't attempt to recurse into the current package

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,10 @@ func vendorize(path, dest string) error {
 	}
 
 	for _, pkg := range pkgs {
+		if pkg.ImportPath == path {
+			// Don't recurse into self.
+			continue
+		}
 		err := vendorize(pkg.ImportPath, dest)
 		if err != nil {
 			return fmt.Errorf("couldn't vendorize %s: %s", pkg.ImportPath, err)


### PR DESCRIPTION
This happens when files in a package appears to import themselves, most
commonly when a package foo has test files in package foo_test that
imports foo.
