### PR TITLE
Fix infinite loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func vendorize(path, dest string) error {
 	if visited[path] {
 		return nil
 	}
+	visited[path] = true
 
 	verbosef("vendorizing %s", path)
 	rootPkg, err := buildPackage(path)
@@ -85,10 +86,6 @@ func vendorize(path, dest string) error {
 	}
 
 	for _, pkg := range pkgs {
-		if pkg.ImportPath == path {
-			// Don't recurse into self.
-			continue
-		}
 		err := vendorize(pkg.ImportPath, dest)
 		if err != nil {
 			return fmt.Errorf("couldn't vendorize %s: %s", pkg.ImportPath, err)
@@ -122,7 +119,6 @@ func vendorize(path, dest string) error {
 			}
 		}
 	}
-	visited[path] = true
 	return nil
 }
 


### PR DESCRIPTION
If foo_test depends on bar and bar depends on foo, vendorize goes into
an infinite loop.

I ran into this in trying to vendor something that uses github.com/garyburd/redigo/redis. The test depends on github.com/garyburd/internal/redistest, which in turn depends on github.com/garyburd/redigo/redis.

(What's happening here is that although go packages cannot have circular imports, vendorize lumps packages with their tests; the graph where each node is [pkg, pkg_test] may indeed have cycles.)

The easy fix is to mark a package as visited as soon as we discover it, not after we process it. I think this is still correct? At least I haven't found any edge cases suggesting otherwise :)