### PR TITLE
Put tempfiles alongside the dest files

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,7 +235,7 @@ func rewriteFile(dest, path string, m map[string]string) error {
 		return nil
 	}
 
-	f, err := ioutil.TempFile("", "vendorize")
+	f, err := ioutil.TempFile(filepath.Dir(dest), "vendorize")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This way os.Rename() won't fail because the src, dest are on different devices.

Fixes #10.