### PR TITLE
Better GOPATH component selection

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type chooseGOPATHTestCase struct {
+	dirs    []string // relative to temp dir
+	gopaths []string // relative to temp dir
+	dest    string
+	want    string
+}
+
+func TestChooseGOPATH(t *testing.T) {
+	for _, tc := range []chooseGOPATHTestCase{
+		// pick the only available gopath
+		{nil, []string{"p1"}, "github.com/user/proj1", "p1"},
+		// pick the first of several when none match
+		{nil, []string{"p1", "p2"}, "github.com/user/proj1", "p1"},
+		// pick the one that exists
+		{[]string{"p2"}, []string{"p1", "p2"}, "github.com/user/proj1", "p2"},
+		// pick the first when both exist
+		{[]string{"p1", "p2"}, []string{"p1", "p2"}, "github.com/user/proj1", "p1"},
+		// pick a path with matching prefix
+		{[]string{"p1", "p2/src/github.com"}, []string{"p1", "p2"}, "github.com/user/proj1", "p2"},
+		// pick a path with better matching prefix
+		{
+			[]string{"p1/src/github.com", "p2/src/github.com/user"},
+			[]string{"p1", "p2"},
+			"github.com/user/proj1",
+			"p2",
+		},
+		// break ties toward the front
+		{
+			[]string{"p1/src/github.com/user/proj1", "p2/src/github.com/user/proj1"},
+			[]string{"p1", "p2"},
+			"github.com/user/proj1",
+			"p1",
+		},
+	} {
+		testChooseGOPATH(t, tc)
+	}
+}
+
+func testChooseGOPATH(t *testing.T, tc chooseGOPATHTestCase) {
+	tempdir, err := ioutil.TempDir("", "vendorize-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempdir)
+
+	tempdir, err = filepath.Abs(tempdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range tc.dirs {
+		if err := os.MkdirAll(filepath.Join(tempdir, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fullGOPATHs := make([]string, len(tc.gopaths))
+	for i, gopath := range tc.gopaths {
+		fullGOPATHs[i] = filepath.Join(tempdir, gopath)
+	}
+	got := chooseGOPATH(fullGOPATHs, tc.dest)
+	want := filepath.Join(tempdir, tc.want)
+	if got != want {
+		t.Errorf("for test case %#v: got: %q; want: %q", tc, got, want)
+	}
+}


### PR DESCRIPTION
Vendorize always puts vendored packages into the location given by the last component of the GOPATH.

This changes vendorize to using the following heuristics:
- Prefer to use the component which contains directories matching the longest prefix of dest
- Prefer components which exist over those that don't
- Break ties by picking the first matching component (a la 'go get')

As one motivating example, consider the following two-component GOPATH:

```
GOPATH=/go:/corp
```

Suppose you are working on a project `github.com/me/foo` which resides at `/go/src/github.com/me/foo`. You wish to vendorize its dependencies in `internal/`, so you run

```
vendorize github.com/me/foo github.com/me/foo/internal
```

Before, vendorize would have put the dependencies in

```
/corp/src/github.com/me/foo/internal,
```

possibly creating several of those nested directories along the way. With this change, vendorize will notice that `github.com/me/foo` already exists in the first gopath, so it will put the vendorized packages where you intended:

```
/go/src/github.com/me/foo/internal
```
